### PR TITLE
Fix prod mode

### DIFF
--- a/lazyloading/src/app/angularjs.module.ts
+++ b/lazyloading/src/app/angularjs.module.ts
@@ -4,6 +4,8 @@ import {RouterModule} from '@angular/router';
 import {module} from './angularjsapp';
 import {UpgradeModule} from '@angular/upgrade/static';
 import {setUpLocationSync} from '@angular/router/upgrade';
+import {setAngularLib} from '@angular/upgrade/static';
+import angular from 'angular';
 
 /**
  * This module is written at the beginning of the upgrade process.
@@ -28,6 +30,7 @@ export class AngularJSModule {
   // The constructor is called only once, so we bootstrap the application
   // only once, when we first navigate to the legacy part of the app.
   constructor(upgrade: UpgradeModule) {
+    setAngularLib(angular);
     upgrade.bootstrap(document.body, [module.name]);
     setUpLocationSync(upgrade);
   }

--- a/lazyloading/src/app/angularjsapp.ts
+++ b/lazyloading/src/app/angularjsapp.ts
@@ -5,7 +5,7 @@ declare const angular: any;
 
 export const module = angular.module('AngularJSApp', ['ui.router']);
 
-module.config(($locationProvider, $stateProvider) => {
+module.config(['$locationProvider', '$stateProvider', ($locationProvider, $stateProvider) => {
   $locationProvider.html5Mode(true);
 
   $stateProvider.state('angularjs_a', {
@@ -38,12 +38,12 @@ module.config(($locationProvider, $stateProvider) => {
     url: '/*path',
     template: ''
   });
-});
+}]);
 
-module.run(($rootScope) => {
+module.run(['$rootScope', ($rootScope) => {
   console.log('Running AngularJS application');
 
   $rootScope.$on('$stateChangeStart', (e, toState, toParams) => {
     console.log('$stateChangeStart', toState, toParams);
   });
-});
+}]);


### PR DESCRIPTION
`angular` reference can't be found without explicit import,
and AngularJS injections are minified so they stopped to work.

This PR fixes all issues with prod mode.